### PR TITLE
chore(ci): bump Node.js to 24 in .github/workflows/ci-cd.yml

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use Node.js version 24, improving the deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->